### PR TITLE
Time out in cmd

### DIFF
--- a/goiscsi_iscsi.go
+++ b/goiscsi_iscsi.go
@@ -39,6 +39,8 @@ const (
 	// ISCSINoObjsFoundExitCode exit code indicates that no records/targets/sessions/portals
 	// found to execute operation on
 	iSCSINoObjsFoundExitCode = 21
+	// Timeout for iscsiadm command to execute
+	Timeout = 30
 )
 
 // LinuxISCSI provides many iSCSI-specific functions.
@@ -98,7 +100,7 @@ func (iscsi *LinuxISCSI) discoverTargets(address string, login bool) ([]ISCSITar
 		return []ISCSITarget{}, err
 	}
 	exe := iscsi.buildISCSICommand([]string{"iscsiadm", "-m", "discovery", "-t", "st", "--portal", address})
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(5)*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(Timeout)*time.Second)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, exe[0], exe[1:]...)
@@ -210,7 +212,7 @@ func (iscsi *LinuxISCSI) performLogin(target ISCSITarget) error {
 	}
 
 	exe := iscsi.buildISCSICommand([]string{"iscsiadm", "-m", "node", "-T", target.Target, "--portal", target.Portal, "-l"})
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(5)*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(Timeout)*time.Second)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, exe[0], exe[1:]...)

--- a/goiscsi_iscsi.go
+++ b/goiscsi_iscsi.go
@@ -19,6 +19,7 @@
 package goiscsi
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -26,6 +27,7 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+	"time"
 )
 
 const (
@@ -96,7 +98,10 @@ func (iscsi *LinuxISCSI) discoverTargets(address string, login bool) ([]ISCSITar
 		return []ISCSITarget{}, err
 	}
 	exe := iscsi.buildISCSICommand([]string{"iscsiadm", "-m", "discovery", "-t", "st", "--portal", address})
-	cmd := exec.Command(exe[0], exe[1:]...)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(5)*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, exe[0], exe[1:]...)
 
 	out, err := cmd.Output()
 	if err != nil {
@@ -205,7 +210,10 @@ func (iscsi *LinuxISCSI) performLogin(target ISCSITarget) error {
 	}
 
 	exe := iscsi.buildISCSICommand([]string{"iscsiadm", "-m", "node", "-T", target.Target, "--portal", target.Portal, "-l"})
-	cmd := exec.Command(exe[0], exe[1:]...)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(5)*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, exe[0], exe[1:]...)
 
 	_, err = cmd.Output()
 

--- a/goiscsi_test.go
+++ b/goiscsi_test.go
@@ -89,6 +89,17 @@ func TestDiscoverTargets(t *testing.T) {
 	}
 }
 
+func TestDiscoverUnreachableTargets(t *testing.T) {
+	c := NewLinuxISCSI(map[string]string{})
+	timeBeforeTestStart := time.Now()
+	_, err := c.DiscoverTargets("127.0.0.1", false)
+	timeAftertest := time.Now()
+	// response should come within Timeout + 2 seconds
+	if err != nil && (timeAftertest.Sub(timeBeforeTestStart).Seconds() > Timeout+2) {
+		t.Error(err.Error())
+	}
+}
+
 func TestLoginLogoutTargets(t *testing.T) {
 	reset()
 	c := NewLinuxISCSI(map[string]string{})
@@ -131,6 +142,23 @@ func TestLoginLoginLogoutTargets(t *testing.T) {
 	if err != nil {
 		t.Error(err.Error())
 		return
+	}
+}
+
+func TestLoginUnreachableTargets(t *testing.T) {
+	reset()
+	c := NewLinuxISCSI(map[string]string{})
+	tgt := ISCSITarget{
+		Portal:   "127.0.0.1",
+		GroupTag: "0",
+		Target:   "iqn.1991-05.com.emc:dummyExample",
+	}
+	timeBeforeTestStart := time.Now()
+	err := c.PerformLogin(tgt)
+	timeAftertest := time.Now()
+	// response should come within Timeout + 2 seconds
+	if err != nil && (timeAftertest.Sub(timeBeforeTestStart).Seconds() > Timeout+2) {
+		t.Error(err.Error())
 	}
 }
 

--- a/goiscsi_test.go
+++ b/goiscsi_test.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 )
 
 var (


### PR DESCRIPTION
# Description
Adding timeOut limit in iscsiadm command. 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Configured 3 iscsi networks (6 targets, 2 out of them were unreachable) on PowerStore array and try to discover the targets with reachable and unreachable portals i.e. try until discovery is not completed with all portals.
- [x] From powerStore driver, tested the above scenario and from log, verified that iscsiadm command is responding within 30 seconds in case if targets are not reachable.
