### PR TITLE
go version bump-up

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/dell/goiscsi
 
-go 1.21
+go 1.22


### PR DESCRIPTION
Updating go version to latest available i.e. => 1.22