### PR TITLE
Support for discovery using interface

### DIFF
--- a/goiscsi.go
+++ b/goiscsi.go
@@ -56,6 +56,9 @@ type ISCSIinterface interface {
 	// DeleteNode delete iSCSI node from iscsid database
 	DeleteNode(target ISCSITarget) error
 
+	// GetInterfaces returns a list of iSCSI interfaces
+	GetInterfaces() ([]ISCSIInterface, error)
+
 	// generic implementations
 	isMock() bool
 	getOptions() map[string]string

--- a/goiscsi.go
+++ b/goiscsi.go
@@ -28,6 +28,10 @@ type ISCSIinterface interface {
 	// returns an array of ISCSITarget instances
 	DiscoverTargets(address string, login bool) ([]ISCSITarget, error)
 
+	// Discover the targets exposed via a given portal and interface
+	// returns an array of ISCSITarget instances
+	DiscoverTargetsWithInterface(address, iface string, login bool) ([]ISCSITarget, error)
+
 	// Get a list of iSCSI initiators defined in a specified file
 	// To use the system default file of "/etc/iscsi/initiatorname.iscsi", provide a filename of ""
 	GetInitiators(filename string) ([]string, error)
@@ -58,6 +62,9 @@ type ISCSIinterface interface {
 
 	// GetInterfaces returns a list of iSCSI interfaces
 	GetInterfaces() ([]ISCSIInterface, error)
+
+	// GetInterfaceForTargetIP returns the iSCSI interfaces for target IP
+	GetInterfaceForTargetIP(address ...string) (map[string]string, error)
 
 	// generic implementations
 	isMock() bool

--- a/goiscsi_iscsi.go
+++ b/goiscsi_iscsi.go
@@ -116,7 +116,7 @@ func (iscsi *LinuxISCSI) discoverTargets(address, iface string, login bool) ([]I
 
 	cmd := exec.CommandContext(ctx, exe[0], exe[1:]...) // #nosec G204
 
-	out, err := cmd.Output()
+	out, err := runCommand(cmd)
 	if err != nil {
 		fmt.Printf("\nError discovering %s: %v", address, err)
 		return []ISCSITarget{}, err
@@ -227,7 +227,7 @@ func (iscsi *LinuxISCSI) performLogin(target ISCSITarget) error {
 
 	cmd := exec.CommandContext(ctx, exe[0], exe[1:]...) // #nosec G204
 
-	_, err = cmd.Output()
+	_, err = runCommand(cmd)
 	if err != nil {
 		if exiterr, ok := err.(*exec.ExitError); ok {
 			// iscsiadm exited with an exit code != 0
@@ -278,7 +278,7 @@ func (iscsi *LinuxISCSI) performLogout(target ISCSITarget) error {
 	exe := iscsi.buildISCSICommand([]string{"iscsiadm", "-m", "node", "-T", target.Target, "--portal", target.Portal, "--logout"})
 	cmd := exec.Command(exe[0], exe[1:]...) // #nosec G204
 
-	_, err = cmd.Output()
+	_, err = runCommand(cmd)
 	if err != nil {
 		if exiterr, ok := err.(*exec.ExitError); ok {
 			// iscsiadm exited with an exit code != 0
@@ -458,7 +458,7 @@ func (iscsi *LinuxISCSI) CreateOrUpdateNode(target ISCSITarget, options map[stri
 	var commands [][]string
 
 	cmd := exec.Command(baseCmd[0], baseCmd[1:]...) // #nosec G204
-	_, err = cmd.Output()
+	_, err = runCommand(cmd)
 	if err != nil {
 		if !isNoObjsExitCode(err) {
 			return err
@@ -497,7 +497,7 @@ func (iscsi *LinuxISCSI) DeleteNode(target ISCSITarget) error {
 	exe := iscsi.buildISCSICommand(
 		[]string{"iscsiadm", "-m", "node", "-p", target.Portal, "-T", target.Target, "-o", "delete"})
 	cmd := exec.Command(exe[0], exe[1:]...) // #nosec G204
-	_, err = cmd.Output()
+	_, err = runCommand(cmd)
 	if err != nil {
 		if isNoObjsExitCode(err) {
 			return nil

--- a/goiscsi_iscsi.go
+++ b/goiscsi_iscsi.go
@@ -136,6 +136,12 @@ func (iscsi *LinuxISCSI) discoverTargets(address string, login bool) ([]ISCSITar
 	return targets, nil
 }
 
+// DiscoverTargetsWithInterface runs an iSCSI discovery with intreface and returns a list of targets.
+func (iscsi *LinuxISCSI) DiscoverTargetsWithInterface(address, iface string, login bool) ([]ISCSITarget, error) {
+	// TODO: Implement the core logic for iSCSI discovery with interface.
+	return nil, nil
+}
+
 // GetInitiators returns a list of initiators on the local system.
 func (iscsi *LinuxISCSI) GetInitiators(filename string) ([]string, error) {
 	return iscsi.getInitiators(filename)
@@ -363,6 +369,11 @@ func (iscsi *LinuxISCSI) GetInterfaces() ([]ISCSIInterface, error) {
 	}
 
 	return interfaces, nil
+}
+
+// GetInterfaceForTargetIP returns the iSCSI interfaces for target IP
+func (iscsi *LinuxISCSI) GetInterfaceForTargetIP(address ...string) (map[string]string, error) {
+	return make(map[string]string, 0), nil
 }
 
 // GetNodes will query information about nodes

--- a/goiscsi_mock.go
+++ b/goiscsi_mock.go
@@ -249,6 +249,11 @@ func (iscsi *MockISCSI) DeleteNode(target ISCSITarget) error {
 	return iscsi.deleteNode(target)
 }
 
+// GetInterfaces returns a list of iSCSI interfaces
+func (iscsi *MockISCSI) GetInterfaces() ([]ISCSIInterface, error) {
+	return []ISCSIInterface{}, nil
+}
+
 // SetCHAPCredentials will set CHAP credentials
 func (iscsi *MockISCSI) SetCHAPCredentials(target ISCSITarget, username, password string) error {
 	options := make(map[string]string)

--- a/goiscsi_mock.go
+++ b/goiscsi_mock.go
@@ -260,8 +260,8 @@ func (iscsi *MockISCSI) GetInterfaceForTargetIP(_ ...string) (map[string]string,
 }
 
 // DiscoverTargetsWithInterface runs an iSCSI discovery with intreface and returns a list of targets.
-func (iscsi *MockISCSI) DiscoverTargetsWithInterface(_, _ string, _ bool) ([]ISCSITarget, error) {
-	return iscsi.discoverTargets(address, login), nil
+func (iscsi *MockISCSI) DiscoverTargetsWithInterface(address, _ string, login bool) ([]ISCSITarget, error) {
+	return iscsi.discoverTargets(address, login)
 }
 
 // SetCHAPCredentials will set CHAP credentials

--- a/goiscsi_mock.go
+++ b/goiscsi_mock.go
@@ -254,6 +254,16 @@ func (iscsi *MockISCSI) GetInterfaces() ([]ISCSIInterface, error) {
 	return []ISCSIInterface{}, nil
 }
 
+// GetInterfaceForTargetIP returns the iSCSI interfaces for target IP
+func (iscsi *MockISCSI) GetInterfaceForTargetIP(address ...string) (map[string]string, error) {
+	return make(map[string]string, 0), nil
+}
+
+// DiscoverTargetsWithInterface runs an iSCSI discovery with intreface and returns a list of targets.
+func (iscsi *MockISCSI) DiscoverTargetsWithInterface(address, iface string, login bool) ([]ISCSITarget, error) {
+	return []ISCSITarget{}, nil
+}
+
 // SetCHAPCredentials will set CHAP credentials
 func (iscsi *MockISCSI) SetCHAPCredentials(target ISCSITarget, username, password string) error {
 	options := make(map[string]string)

--- a/goiscsi_mock.go
+++ b/goiscsi_mock.go
@@ -255,12 +255,12 @@ func (iscsi *MockISCSI) GetInterfaces() ([]ISCSIInterface, error) {
 }
 
 // GetInterfaceForTargetIP returns the iSCSI interfaces for target IP
-func (iscsi *MockISCSI) GetInterfaceForTargetIP(address ...string) (map[string]string, error) {
+func (iscsi *MockISCSI) GetInterfaceForTargetIP(_ ...string) (map[string]string, error) {
 	return make(map[string]string, 0), nil
 }
 
 // DiscoverTargetsWithInterface runs an iSCSI discovery with intreface and returns a list of targets.
-func (iscsi *MockISCSI) DiscoverTargetsWithInterface(address, iface string, login bool) ([]ISCSITarget, error) {
+func (iscsi *MockISCSI) DiscoverTargetsWithInterface(_, _ string, _ bool) ([]ISCSITarget, error) {
 	return []ISCSITarget{}, nil
 }
 

--- a/goiscsi_mock.go
+++ b/goiscsi_mock.go
@@ -261,7 +261,7 @@ func (iscsi *MockISCSI) GetInterfaceForTargetIP(_ ...string) (map[string]string,
 
 // DiscoverTargetsWithInterface runs an iSCSI discovery with intreface and returns a list of targets.
 func (iscsi *MockISCSI) DiscoverTargetsWithInterface(_, _ string, _ bool) ([]ISCSITarget, error) {
-	return []ISCSITarget{}, nil
+	return iscsi.discoverTargets(address, login), nil
 }
 
 // SetCHAPCredentials will set CHAP credentials

--- a/goiscsi_test.go
+++ b/goiscsi_test.go
@@ -1214,8 +1214,22 @@ func TestPerformLogin(t *testing.T) {
 }
 
 func simulateExitCode(exitCode int) error {
-	cmd := exec.Command("sh", "-c", fmt.Sprintf("exit %d", exitCode))
+	// Sanitize the input to ensure it's a valid exit code
+	sanitizedExitCode, err := sanitizeInput(exitCode)
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.Command("sh", "-c", fmt.Sprintf("exit %d", sanitizedExitCode))
 	return cmd.Run()
+}
+
+func sanitizeInput(exitCode int) (int, error) {
+	// Ensure the exit code is within the range of valid exit codes: 0-255 for Unix-like systems
+	if exitCode < 0 || exitCode > 255 {
+		return 0, errors.New("invalid exit code: must be within 0-255")
+	}
+	return exitCode, nil
 }
 
 func TestPerformLogout(t *testing.T) {

--- a/goiscsi_test.go
+++ b/goiscsi_test.go
@@ -1214,22 +1214,8 @@ func TestPerformLogin(t *testing.T) {
 }
 
 func simulateExitCode(exitCode int) error {
-	// Sanitize the input to ensure it's a valid exit code
-	sanitizedExitCode, err := sanitizeInput(exitCode)
-	if err != nil {
-		return err
-	}
-
-	cmd := exec.Command("sh", "-c", fmt.Sprintf("exit %d", sanitizedExitCode))
+	cmd := exec.Command("sh", "-c", fmt.Sprintf("exit %d", exitCode)) // #nosec G204
 	return cmd.Run()
-}
-
-func sanitizeInput(exitCode int) (int, error) {
-	// Ensure the exit code is within the range of valid exit codes: 0-255 for Unix-like systems
-	if exitCode < 0 || exitCode > 255 {
-		return 0, errors.New("invalid exit code: must be within 0-255")
-	}
-	return exitCode, nil
 }
 
 func TestPerformLogout(t *testing.T) {

--- a/goiscsi_test.go
+++ b/goiscsi_test.go
@@ -264,6 +264,7 @@ func TestDiscoverTargetsWithInterface(t *testing.T) {
 		})
 	}
 }
+
 func TestLoginLogoutTargets(t *testing.T) {
 	reset()
 	c := NewLinuxISCSI(map[string]string{})
@@ -274,7 +275,7 @@ func TestLoginLogoutTargets(t *testing.T) {
 	}
 
 	// Mock the runCommand function to simulate environment where iscsiadm is not found
-	runCommand = func(cmd *exec.Cmd) ([]byte, error) {
+	runCommand = func(_ *exec.Cmd) ([]byte, error) {
 		return nil, errors.New("exec: \"iscsiadm\": executable file not found in $PATH")
 	}
 

--- a/goiscsi_test.go
+++ b/goiscsi_test.go
@@ -84,19 +84,120 @@ func TestPolymorphichCapability(t *testing.T) {
 }
 
 func TestDiscoverTargets(t *testing.T) {
-	reset()
-	c := NewLinuxISCSI(map[string]string{})
-	_, err := c.DiscoverTargets(testPortal, false)
-	expectedError := errors.New("exec: \"iscsiadm\": executable file not found in $PATH")
-	if err.Error() != expectedError.Error() {
-		t.Errorf("Expected error: %v, but got: %v", expectedError, err)
-		return
+	tests := []struct {
+		name    string
+		address string
+		iface   string
+		login   bool
+		cmdOut  []byte
+		cmdErr  error
+		want    []ISCSITarget
+		wantErr bool
+	}{
+		{
+			name:    "valid address with target",
+			address: "1.1.1.1",
+			iface:   "iface0",
+			login:   false,
+			cmdOut:  []byte("1.1.1.1:3260,0 iqn.1992-04.com.emc:600009700bcbb70e3287017400000001"),
+			cmdErr:  nil,
+			want: []ISCSITarget{
+				{Portal: "1.1.1.1:3260", GroupTag: "0", Target: "iqn.1992-04.com.emc:600009700bcbb70e3287017400000001"},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "error invalid address",
+			address: "invalid address",
+			iface:   "iface0",
+			login:   false,
+			cmdOut:  nil,
+			cmdErr:  fmt.Errorf("invalid address"),
+			want:    []ISCSITarget{},
+			wantErr: true,
+		},
+		{
+			name:    "error discovering targets",
+			address: "1.1.1.1",
+			iface:   "iface0",
+			login:   false,
+			cmdOut:  nil,
+			cmdErr:  fmt.Errorf("iscsiadm error"),
+			want:    []ISCSITarget{},
+			wantErr: true,
+		},
+		{
+			name:    "valid address without target",
+			address: "2.2.2.2",
+			iface:   "",
+			login:   false,
+			cmdOut:  []byte(""),
+			cmdErr:  nil,
+			want:    []ISCSITarget{},
+			wantErr: false,
+		},
+		{
+			name:    "multiple targets",
+			address: "3.3.3.3",
+			iface:   "iface0",
+			login:   false,
+			cmdOut:  []byte("3.3.3.3:3260,1 iqn.1992-04.com.emc:600009700bcbb70e3287017400000002\n3.3.3.3:3260,2 iqn.1992-04.com.emc:600009700bcbb70e3287017400000003"),
+			cmdErr:  nil,
+			want: []ISCSITarget{
+				{Portal: "3.3.3.3:3260", GroupTag: "1", Target: "iqn.1992-04.com.emc:600009700bcbb70e3287017400000002"},
+				{Portal: "3.3.3.3:3260", GroupTag: "2", Target: "iqn.1992-04.com.emc:600009700bcbb70e3287017400000003"},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "interface specified without login",
+			address: "4.4.4.4",
+			iface:   "iface1",
+			login:   false,
+			cmdOut:  []byte("4.4.4.4:3260,0 iqn.1992-04.com.emc:600009700bcbb70e3287017400000004"),
+			cmdErr:  nil,
+			want: []ISCSITarget{
+				{Portal: "4.4.4.4:3260", GroupTag: "0", Target: "iqn.1992-04.com.emc:600009700bcbb70e3287017400000004"},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "error on interface specified",
+			address: "invalid",
+			iface:   "iface0",
+			login:   false,
+			cmdOut:  nil,
+			cmdErr:  fmt.Errorf("iscsiadm error"),
+			want:    []ISCSITarget{},
+			wantErr: true,
+		},
 	}
-	expectedError = errors.New("error invalid IP or portal address")
-	_, err = c.DiscoverTargets("", false)
-	if err.Error() != expectedError.Error() {
-		t.Errorf("Expected error: %v, but got: %v", expectedError, err)
-		return
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a new instance of LinuxISCSI
+			reset()
+			iscsi := NewLinuxISCSI(map[string]string{})
+
+			// Set up mocks or other dependencies
+			runCommand = func(_ *exec.Cmd) ([]byte, error) {
+				return tt.cmdOut, tt.cmdErr
+			}
+
+			// Call the discoverTargets function
+			got, err := iscsi.discoverTargets(tt.address, tt.iface, tt.login)
+
+			// Check if the error matches the expected error
+			if (err != nil) != tt.wantErr {
+				t.Errorf("discoverTargets() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			// Check if the result matches the expected result
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("discoverTargets() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -113,41 +214,82 @@ func TestDiscoverUnreachableTargets(t *testing.T) {
 
 func TestDiscoverTargetsWithInterface(t *testing.T) {
 	reset()
-	c := NewLinuxISCSI(map[string]string{})
+	iscsi := NewLinuxISCSI(map[string]string{})
 
-	expectedError := errors.New("error invalid IP or portal address")
-	_, err := c.DiscoverTargetsWithInterface("", "iface0", false)
-	if err.Error() != expectedError.Error() {
-		t.Errorf("Expected error: %v, but got: %v", expectedError, err)
-		return
+	tests := []struct {
+		name        string
+		address     string
+		iface       string
+		login       bool
+		cmdOut      []byte
+		cmdErr      error
+		expectedErr string
+	}{
+		{
+			name:        "test empty address",
+			address:     "",
+			iface:       "iface0",
+			login:       false,
+			cmdOut:      nil,
+			cmdErr:      nil,
+			expectedErr: "error invalid IP or portal address",
+		},
+		{
+			name:        "test iscsiadm not in path",
+			address:     "1.1.1.1",
+			iface:       "iface0",
+			login:       false,
+			cmdOut:      nil,
+			cmdErr:      fmt.Errorf("exec: \"iscsiadm\": executable file not found in $PATH"),
+			expectedErr: "exec: \"iscsiadm\": executable file not found in $PATH",
+		},
 	}
 
-	expectedError = errors.New("exec: \"iscsiadm\": executable file not found in $PATH")
-	_, err = c.DiscoverTargetsWithInterface(testPortal, "iface0", false)
-	if err.Error() != expectedError.Error() {
-		t.Errorf("Expected error: %v, but got: %v", expectedError, err)
-		return
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			runCommand = func(_ *exec.Cmd) ([]byte, error) {
+				return test.cmdOut, test.cmdErr
+			}
+			targets, err := iscsi.DiscoverTargetsWithInterface(test.address, test.iface, test.login)
+			if err != nil {
+				if err.Error() != test.expectedErr {
+					t.Errorf("Expected error: %v, but got: %v", test.expectedErr, err)
+				}
+			} else {
+				// if test doesn't expect an error but returns targets length is 0, fail.
+				if len(targets) == 0 && test.expectedErr != "" {
+					t.Errorf("Expected error: %v, but got no error", test.expectedErr)
+				}
+			}
+		})
 	}
 }
-
 func TestLoginLogoutTargets(t *testing.T) {
 	reset()
 	c := NewLinuxISCSI(map[string]string{})
 	tgt := ISCSITarget{
-		Portal:   testPortal,
+		Portal:   "1.1.1.1", // Adjust this based on your `testPortal` variable
 		GroupTag: "0",
-		Target:   testTarget,
+		Target:   "iqn.1992-04.com.emc:600009700bcbb70e3287017400000001", // Adjust this based on your `testTarget` variable
 	}
+
+	// Mock the runCommand function to simulate environment where iscsiadm is not found
+	runCommand = func(cmd *exec.Cmd) ([]byte, error) {
+		return nil, errors.New("exec: \"iscsiadm\": executable file not found in $PATH")
+	}
+
+	expectedError := "exec: \"iscsiadm\": executable file not found in $PATH"
+
+	// Test PerformLogin
 	err := c.PerformLogin(tgt)
-	expectedError := errors.New("exec: \"iscsiadm\": executable file not found in $PATH")
-	if err.Error() != expectedError.Error() {
+	if err == nil || err.Error() != expectedError {
 		t.Errorf("Expected error: %v, but got: %v", expectedError, err)
-		return
 	}
+
+	// Test PerformLogout
 	err = c.PerformLogout(tgt)
-	if err.Error() != expectedError.Error() {
+	if err == nil || err.Error() != expectedError {
 		t.Errorf("Expected error: %v, but got: %v", expectedError, err)
-		return
 	}
 }
 
@@ -848,6 +990,109 @@ func TestGetInterfaceForTargetIP(t *testing.T) {
 			// Check if the result matches the expected result
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("GetInterfaceForTargetIP() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetOptions(t *testing.T) {
+	// Define the test cases
+	tests := []struct {
+		name     string
+		input    *ISCSIType
+		expected map[string]string
+	}{
+		{
+			name: "Non-empty options",
+			input: &ISCSIType{
+				options: map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+				},
+			},
+			expected: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+		},
+		{
+			name: "Empty options",
+			input: &ISCSIType{
+				options: map[string]string{},
+			},
+			expected: map[string]string{},
+		},
+		{
+			name:     "Nil options",
+			input:    &ISCSIType{},
+			expected: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := test.input.getOptions()
+			if !reflect.DeepEqual(result, test.expected) {
+				t.Errorf("Expected %v, but got %v", test.expected, result)
+			}
+		})
+	}
+}
+
+func TestPerformLogin(t *testing.T) {
+	iscsi := &LinuxISCSI{}
+
+	tests := []struct {
+		name        string
+		target      ISCSITarget
+		cmdOut      []byte
+		cmdErr      error
+		expectedErr string
+	}{
+		{
+			name:        "test invalid portal address",
+			target:      ISCSITarget{Portal: "invalid", Target: "iqn.1992-04.com.emc:600009700bcbb70e3287017400000001"},
+			cmdOut:      nil,
+			cmdErr:      nil,
+			expectedErr: "error invalid IP or portal address",
+		},
+		{
+			name:        "test invalid IQN target",
+			target:      ISCSITarget{Portal: "1.1.1.1", Target: "invalid"},
+			cmdOut:      nil,
+			cmdErr:      fmt.Errorf("error invalid IQN Target invalid: invalid IQN"),
+			expectedErr: "error invalid IQN",
+		},
+		{
+			name:        "test iscsiadm executable not found",
+			target:      ISCSITarget{Portal: "1.1.1.1", Target: "iqn.1992-04.com.emc:600009700bcbb70e3287017400000001"},
+			cmdOut:      nil,
+			cmdErr:      fmt.Errorf("exec: \"iscsiadm\": executable file not found in $PATH"),
+			expectedErr: "exec: \"iscsiadm\": executable file not found in $PATH",
+		},
+		{
+			name:        "test successful login",
+			target:      ISCSITarget{Portal: "1.1.1.1", Target: "iqn.1992-04.com.emc:600009700bcbb70e3287017400000001"},
+			cmdOut:      nil,
+			cmdErr:      nil,
+			expectedErr: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			runCommand = func(_ *exec.Cmd) ([]byte, error) {
+				return test.cmdOut, test.cmdErr
+			}
+			err := iscsi.performLogin(test.target)
+			if err != nil {
+				if err.Error() != test.expectedErr {
+					t.Errorf("Expected error: %v, but got: %v", test.expectedErr, err)
+				}
+			} else {
+				if test.expectedErr != "" {
+					t.Errorf("Expected error: %v, but got no error", test.expectedErr)
+				}
 			}
 		})
 	}

--- a/goiscsi_types.go
+++ b/goiscsi_types.go
@@ -68,6 +68,16 @@ type ISCSISession struct {
 	PasswordIn           string
 }
 
+// ISCSIInterface represents an iSCSI interface with all its fields
+type ISCSIInterface struct {
+	IfaceName       string
+	TransportName   string
+	HardwareAddress string
+	IPAddress       string
+	NetIfaceName    string
+	InitiatorName   string
+}
+
 // ISCSINode defines an iSCSI node info
 type ISCSINode struct {
 	Target string

--- a/utils.go
+++ b/utils.go
@@ -57,7 +57,7 @@ func validateIQN(iqn string) error {
 }
 
 func filterIPsForInterface(ifaceName string, ipAddress ...string) ([]string, error) {
-	fmt.Printf("\nDEBUG ifaceName : %v", ifaceName)
+
 	filterredIPs := make([]string, 0)
 	iface, err := net.InterfaceByName(ifaceName)
 	if err != nil {
@@ -72,7 +72,7 @@ func filterIPsForInterface(ifaceName string, ipAddress ...string) ([]string, err
 	}
 
 	for _, ipAddr := range ipAddress {
-		fmt.Printf("\nDEBUG ipAddr : %v", ipAddr)
+
 		ip := net.ParseIP(ipAddr)
 		if ip == nil {
 			fmt.Printf("\nError invalid IP address: %s", ipAddr)
@@ -85,8 +85,6 @@ func filterIPsForInterface(ifaceName string, ipAddress ...string) ([]string, err
 				fmt.Printf("\nError failed to parse address %s of interface %s : %v", addr.String(), ifaceName, err)
 				continue
 			}
-			fmt.Printf("\nDEBUG ifaceIP : %v", ifaceIP)
-			fmt.Printf("\nDEBUG ifaceSubnet : %v", ifaceSubnet)
 
 			// Check if the IP belongs to the subnet
 			if ifaceSubnet.Contains(ip) || ifaceIP.Equal(ip) {
@@ -96,7 +94,7 @@ func filterIPsForInterface(ifaceName string, ipAddress ...string) ([]string, err
 		if found {
 			filterredIPs = append(filterredIPs, ipAddr)
 		}
-		fmt.Printf("\nDEBUG filterredIPs : %v", filterredIPs)
+
 	}
 
 	return filterredIPs, nil

--- a/utils.go
+++ b/utils.go
@@ -57,17 +57,17 @@ func validateIQN(iqn string) error {
 }
 
 func filterIPsForInterface(ifaceName string, ipAddress ...string) ([]string, error) {
-	filterredIPs := make([]string, 0)
+	filteredIPs := make([]string, 0)
 	iface, err := net.InterfaceByName(ifaceName)
 	if err != nil {
 		fmt.Printf("\nError could not find interface %s : %v", ifaceName, err)
-		return filterredIPs, err
+		return filteredIPs, err
 	}
 
 	addrs, err := iface.Addrs()
 	if err != nil {
 		fmt.Printf("\nError failed to get addresses of interface %s : %v", ifaceName, err)
-		return filterredIPs, err
+		return filteredIPs, err
 	}
 
 	for _, ipAddr := range ipAddress {
@@ -77,7 +77,6 @@ func filterIPsForInterface(ifaceName string, ipAddress ...string) ([]string, err
 			fmt.Printf("\nError invalid IP address: %s", ipAddr)
 			continue
 		}
-		found := false
 		for _, addr := range addrs {
 			ifaceIP, ifaceSubnet, err := net.ParseCIDR(addr.String())
 			if err != nil {
@@ -87,14 +86,12 @@ func filterIPsForInterface(ifaceName string, ipAddress ...string) ([]string, err
 
 			// Check if the IP belongs to the subnet
 			if ifaceSubnet.Contains(ip) || ifaceIP.Equal(ip) {
-				found = true
+				filteredIPs = append(filteredIPs, ipAddr)
+				break
 			}
-		}
-		if found {
-			filterredIPs = append(filterredIPs, ipAddr)
 		}
 
 	}
 
-	return filterredIPs, nil
+	return filteredIPs, nil
 }

--- a/utils.go
+++ b/utils.go
@@ -57,7 +57,6 @@ func validateIQN(iqn string) error {
 }
 
 func filterIPsForInterface(ifaceName string, ipAddress ...string) ([]string, error) {
-
 	filterredIPs := make([]string, 0)
 	iface, err := net.InterfaceByName(ifaceName)
 	if err != nil {


### PR DESCRIPTION
# Description
Add support for discovery using iSCSI interface.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|dell/csm#1714 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] The PowerStore driver was successfully installed in both default and iscsi interface environments, with iSCSI discovery working as expected, and Cert-CSI scale testing results passing.